### PR TITLE
Remove a dead image link

### DIFF
--- a/bleach.txt
+++ b/bleach.txt
@@ -132,7 +132,6 @@
 [Mamma and her kits!](https://gfycat.com/hollowdigitalcorydorascatfish-kittens-cats-cute)
 [Look at those eyes!](https://i.redd.it/z680rx2typ251.jpg)
 [Here's a friendly frog!](https://gfycat.com/necessarypowerlesscrocodileskink)
-[Here you are!](https://i.redd.it/thncg165w4251.jpg)
 [Here's a handful of cuteness!](https://i.imgur.com/cyHOUQ9.gifv)
 [Here's a real jumpy cat!](https://gfycat.com/oblongunknownbrant-adorable-cuteness-kitten)
 [Your wish is my command!](https://gfycat.com/exaltedtartantipodesgreenparakeet-funny-cat)


### PR DESCRIPTION
I noticed that the bot posted a dead link in a recent comment. Figured it shouldn't do that.

It's entirely possible there are other dead links; I'm just removing the one I saw.